### PR TITLE
Include unique constraint

### DIFF
--- a/pg-core.ts
+++ b/pg-core.ts
@@ -12,5 +12,6 @@ export * from "https://esm.sh/drizzle-orm@0.23.8/pg-core/schema";
 export * from "https://esm.sh/drizzle-orm@0.23.8/pg-core/session";
 export * from "https://esm.sh/drizzle-orm@0.23.8/pg-core/subquery";
 export * from "https://esm.sh/drizzle-orm@0.23.8/pg-core/table";
+export * from "https://esm.sh/drizzle-orm@0.23.8/pg-core/unique-constraint.ts";
 export * from "https://esm.sh/drizzle-orm@0.23.8/pg-core/utils";
 export * from "https://esm.sh/drizzle-orm@0.23.8/pg-core/view";


### PR DESCRIPTION
As of v0.23.85 unique constraints, part of main branch of drizzle-orm, is not included in DENO version.